### PR TITLE
CMakeLists.txt cleanup + automated RPM/deb release pipeline

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -6,6 +6,9 @@ on:
       - 'v*'     # läuft nur bei Tags wie v0.1.0, v1.2.3
   workflow_dispatch:  # optional: manuell startbar
 
+permissions:
+  contents: write
+
 jobs:
   deb:
     runs-on: ubuntu-latest
@@ -100,3 +103,29 @@ jobs:
           for f in obj-*/CMakeCache.txt; do [ -f "$f" ] && { echo ">>> $f"; sed -n '1,120p' "$f"; }; done
           echo "---- debhelper logs (tail) ----"
           find ./debian -maxdepth 2 -type f -name '*.log' -print0 | xargs -0 -r -I{} sh -c 'echo ">>> {}"; tail -n 200 "{}"'
+
+  release:
+    needs: deb
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download .deb artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: kfritz-trixie
+          path: dist
+
+      - name: Create or update GitHub Release
+        # No .plasmoid here — kfritz needs a compiled C++ plugin, a plain
+        # zip of package/ wouldn't be installable via kpackagetool6/GHNS.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 \
+            || gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --title "$TAG" --generate-notes
+          gh release upload "$TAG" dist/dist/*.deb --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/obs-submit.yml
+++ b/.github/workflows/obs-submit.yml
@@ -1,0 +1,137 @@
+name: obs-submit
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  submit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Determine version from tag
+        id: ver
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Install osc
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends osc
+
+      - name: Configure osc credentials
+        env:
+          OBS_USER: ${{ secrets.OBS_USER }}
+          OBS_PASSWORD: ${{ secrets.OBS_PASSWORD }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.config/osc
+          cat > ~/.config/osc/oscrc <<OSCRC
+          [general]
+          apiurl = https://api.opensuse.org
+
+          [https://api.opensuse.org]
+          user = ${OBS_USER}
+          pass = ${OBS_PASSWORD}
+          credentials_mgr_class = osc.credentials.PlaintextConfigFileCredentialsManager
+          OSCRC
+          chmod 600 ~/.config/osc/oscrc
+
+      - name: Checkout OBS package
+        run: osc checkout home:Agundur/KFritz -o obs-pkg
+
+      - name: Sync spec from repo and pin _service to this tag
+        # The spec/_service in obs-pkg/ are separate copies OBS keeps — they
+        # do not auto-update just because packaging/ changed in git. Copy the
+        # spec wholesale, and rewrite _service to pin the obs_scm git service
+        # to this exact tag (previously a tar_scm/HEAD service with a
+        # hand-bumped "version" param — obs_scm avoids that second manual
+        # sync point entirely, same pattern as KClaude).
+        run: |
+          set -euo pipefail
+          cp packaging/kfritz.spec obs-pkg/kfritz.spec
+          cd obs-pkg
+          cat > _service <<SERVICE
+          <services>
+            <service name="obs_scm">
+              <param name="url">https://github.com/Agundur-KDE/kfritz.git</param>
+              <param name="scm">git</param>
+              <param name="revision">${{ steps.ver.outputs.tag }}</param>
+            </service>
+          </services>
+          SERVICE
+          sed -i "s/^Version:.*/Version:        ${{ steps.ver.outputs.version }}/" kfritz.spec
+          cat _service
+
+      - name: Commit to OBS
+        # osc exits non-zero for a genuine no-op commit too (same tag already
+        # submitted, needs -f to force an empty commit) — that case is fine to
+        # swallow. A real API error (e.g. transient 5xx) also exits non-zero
+        # and looks the same unless we check the actual output for it.
+        run: |
+          set -euo pipefail
+          cd obs-pkg
+          if ! osc commit -m "Update to ${{ steps.ver.outputs.tag }}" 2>&1 | tee /tmp/osc-commit.log; then
+            if grep -qE "Server returned an error|HTTP Error" /tmp/osc-commit.log; then
+              echo "osc commit failed against the OBS API, see log above" >&2
+              exit 1
+            fi
+            echo "nothing to commit, continuing"
+          fi
+
+      - name: Force source service rerun
+        # A commit with no file changes (e.g. tag == already-configured revision)
+        # does not trigger OBS to re-run the obs_scm service on its own.
+        run: osc api -X POST "/source/home:Agundur/KFritz?cmd=runservice"
+
+      - name: Wait for OBS build to settle
+        run: |
+          set -euo pipefail
+          cd obs-pkg
+          for i in $(seq 1 60); do
+            out="$(osc results)"
+            echo "$out"
+            if ! grep -qE "broken|blocked|scheduled|building|dispatching|signing|finished\*" <<<"$out"; then
+              break
+            fi
+            sleep 20
+          done
+          echo "$out"
+          if grep -qE "failed|broken|unresolvable" <<<"$out"; then
+            echo "OBS build did not succeed, see log above" >&2
+            exit 1
+          fi
+
+      - name: Download RPMs
+        run: |
+          set -euo pipefail
+          cd obs-pkg
+          mkdir -p ../rpms
+          osc getbinaries openSUSE_Tumbleweed x86_64 -d ../rpms
+          osc getbinaries openSUSE_Tumbleweed i586 -d ../rpms
+          rm -f ../rpms/*.src.rpm ../rpms/_buildenv ../rpms/_statistics ../rpms/rpmlint.log
+          ls -la ../rpms
+
+      - name: Create or update GitHub Release with RPMs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.ver.outputs.tag }}"
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 \
+            || gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --title "$TAG" --generate-notes
+          gh release upload "$TAG" rpms/*.rpm --repo "$GITHUB_REPOSITORY" --clobber

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,151 +3,51 @@
 # SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only OR LicenseRef-KDE-Accepted-GPL
 
 
-cmake_minimum_required(VERSION 3.31)
+cmake_minimum_required(VERSION 3.16)
 
 project(kfritz)
 
 set(PROJECT_VERSION "0.1.1")
 
-set(PROJECT_DEP_VERSION "6.2.90")
 set(QT_MIN_VERSION "6.7.0")
 set(KF6_MIN_VERSION "6.10.0")
-set(ACCOUNTSQT_DEP_VERSION "1.13")
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(ECM ${KF6_MIN_VERSION} REQUIRED NO_MODULE)
-set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
-set(INSTALL_SDDM_THEME TRUE)
+set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
 
 include(KDEInstallDirs)
 include(KDECMakeSettings)
 include(KDECompilerSettings NO_POLICY_SCOPE)
-include(ECMFindQmlModule)
-include(ECMGenerateExportHeader)
-include(ECMInstallIcons)
-include(ECMMarkAsTest)
-include(ECMMarkNonGuiExecutable)
-include(ECMOptionalAddSubdirectory)
-include(ECMQtDeclareLoggingCategory)
-include(ECMSetupVersion)
-include(FeatureSummary)
-include(CheckIncludeFiles)
-include(KDEClangFormat)
-include(KDEGitCommitHooks)
-
-# include(KDEGitCommitHooks)
-if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
-    include(KDEGitCommitHooks OPTIONAL)
-endif()
-
 include(ECMQmlModule)
-include(ECMConfiguredInstall)
-include(GNUInstallDirs)
-
-
-option(BUILD_KCM_MOUSE_X11 "Build the Mouse KCM's X11 backend" ON)
-
-
 
 find_package(Qt6 ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS
-   Core
-   Quick
-    QuickWidgets
+    Core
+    Qml
     Network
     Xml
-    Widgets
-    # Svg
-    #Concurrent
-    #Core5Compat
-    # Sql # kcms/activities
-
 )
-
 
 find_package(KF6 ${KF6_MIN_VERSION} REQUIRED COMPONENTS
-   # Auth
-    #Crash
-    Config
     I18n
-    KCMUtils
-    # NewStuff
+    CoreAddons
     Notifications
-    NotifyConfig
-    # Attica
-    # Runner
-    GlobalAccel
-    CoreAddons # KSharedDataCache required by KImageCache, KStringHandler required by FolderModel
-    GuiAddons # KImageCache
-    # DBusAddons
-    Config
-    WidgetsAddons
-    Codecs
-    Package
-    IconThemes
-    XmlGui
-    # Svg
 )
-
-
-find_package(KF6Kirigami ${KF6_MIN_VERSION} CONFIG)
-set_package_properties(KF6Kirigami PROPERTIES
-    DESCRIPTION "A QtQuick based components set"
-    PURPOSE "Required at runtime by many KCMs"
-    TYPE RUNTIME
-)
-
-
-find_package(KF6KirigamiAddons 1.0.0 CONFIG)
-set_package_properties(KF6KirigamiAddons PROPERTIES
-    DESCRIPTION "Extra controls for Kirigami applications"
-    PURPOSE "Required at runtime for Kickoff"
-    TYPE RUNTIME
-)
-
-find_package(KF6QQC2DesktopStyle ${KF6_MIN_VERSION} CONFIG)
-set_package_properties(KF6QQC2DesktopStyle PROPERTIES
-    DESCRIPTION "QtQuickControls 2 style that uses QWidget's QStyle for painting"
-    PURPOSE "Required at runtime by many KCMs"
-    TYPE RUNTIME
-)
-
-find_package(X11)
-set_package_properties(X11 PROPERTIES
-    DESCRIPTION "X11 libraries"
-    URL "https://www.x.org"
-    PURPOSE "Required for building the X11 based workspace"
-    TYPE REQUIRED
-)
-
-if(X11_FOUND)
-  set(HAVE_X11 1)
-endif()
 
 ki18n_install(translate
     INSTALL_DESTINATION ${KDE_INSTALL_LOCALEDIR}
 )
-
 
 install(FILES
     ${CMAKE_SOURCE_DIR}/package/metadata/notifyrc/kfritz.notifyrc
     DESTINATION ${KDE_INSTALL_KNOTIFYRCDIR}
 )
 
-install(DIRECTORY contents/
-    DESTINATION ${KDE_INSTALL_DATADIR}/plasma/plasmoids/de.agundur.kfritz/
-    FILES_MATCHING PATTERN "*.qml"
-                   PATTERN "*.svg"
-                   PATTERN "*.js"
-                   PATTERN "*.json"
-                   PATTERN "*.png"
-)
-
-
 add_subdirectory(package)
 
 install(DIRECTORY package/ DESTINATION ${KDE_INSTALL_DATADIR}/plasma/plasmoids/de.agundur.kfritz)
 
 install(FILES package/metadata/de.agundur.kfritz.appdata.xml
-        DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo)
+        DESTINATION ${KDE_INSTALL_DATADIR}/metainfo)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,17 @@ install(FILES
 
 add_subdirectory(package)
 
-install(DIRECTORY package/ DESTINATION ${KDE_INSTALL_DATADIR}/plasma/plasmoids/de.agundur.kfritz)
+# Only ship the plasmoid metadata + QML/config, not the C++ plugin sources or
+# the package/metadata/ subdir (notifyrc/appdata.xml — those install to their
+# own proper locations below already). A blanket install(DIRECTORY package/)
+# was shipping raw .cpp/.h/CMakeLists.txt as inert data files alongside the
+# actually-used compiled plugin (which ecm_add_qml_module installs separately
+# into the Qt QML plugin dir).
+install(FILES package/metadata.json
+        DESTINATION ${KDE_INSTALL_DATADIR}/plasma/plasmoids/de.agundur.kfritz)
+
+install(DIRECTORY package/contents/
+        DESTINATION ${KDE_INSTALL_DATADIR}/plasma/plasmoids/de.agundur.kfritz/contents)
 
 install(FILES package/metadata/de.agundur.kfritz.appdata.xml
         DESTINATION ${KDE_INSTALL_DATADIR}/metainfo)

--- a/debian/control
+++ b/debian/control
@@ -4,14 +4,8 @@ Priority: optional
 Maintainer: Agundur <info@agundur.de>
 Build-Depends: debhelper-compat (= 13),
  cmake, ninja-build, extra-cmake-modules, pkg-kde-tools, gettext, pkg-config,
- qt6-base-dev, qt6-declarative-dev, qt6-declarative-dev-tools, qt6-svg-dev, qt6-base-dev-tools,
- qt6-declarative-private-dev, qt6-base-private-dev,
- libplasma-dev,
- libkf6i18n-dev, libkf6notifications-dev, libkf6package-dev, libkf6declarative-dev,
- libkirigami-dev, libkf6coreaddons-dev, libkf6config-dev,
- libkf6kcmutils-dev, libkf6notifyconfig-dev, libkf6globalaccel-dev,
- libkf6guiaddons-dev, libkf6widgetsaddons-dev, libkf6codecs-dev,
- libkf6iconthemes-dev, libkf6xmlgui-dev,
+ qt6-base-dev, qt6-declarative-dev, qt6-declarative-dev-tools, qt6-base-dev-tools,
+ libkf6i18n-dev, libkf6notifications-dev, libkf6coreaddons-dev,
  appstream
 Standards-Version: 4.7.0
 Rules-Requires-Root: no

--- a/debian/rules
+++ b/debian/rules
@@ -15,11 +15,6 @@ override_dh_auto_configure:
 override_dh_auto_test:
 	:
 
-override_dh_auto_install:
-	dh_auto_install
-	# keine Quelltexte ins Paket:
-	rm -f debian/kfritz/usr/share/plasma/plasmoids/de.agundur.kfritz/plugin/*.{cpp,h,CMakeLists.txt} || true
-
 override_dh_auto_clean:
 	rm -rf obj-* build || true
 	dh_auto_clean || true

--- a/packaging/kfritz.spec
+++ b/packaging/kfritz.spec
@@ -1,52 +1,71 @@
+%ifarch aarch64
+%undefine source_date_epoch_from_changelog
+%endif
+
 Name:           kfritz
-Version:        0.1.0
-
+Version:        0.1.1
 Release:        1%{?dist}
-URL:            https://github.com/Agundur-KDE/kfritz
-Summary:        A KDE Plasma 6 callmonitor plasmoid for the AVM FRITZ!Box on your desktop.
-License:        GPL-3.0-or-later
-Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz#/kfritz-%{version}.tar.gz
+Summary:        KDE Plasma 6 callmonitor plasmoid for the AVM FRITZ!Box
 
-# --- Build requirements (C++/CMake + Qt6 + KF6/Plasma 6)
+License:        GPL-3.0-or-later
+URL:            https://github.com/Agundur-KDE/kfritz
+
+
 BuildRequires:  cmake
 BuildRequires:  gcc-c++
+BuildRequires:  gettext
 BuildRequires:  extra-cmake-modules
-BuildRequires:  qt6-qtbase-devel
-BuildRequires:  qt6-qtdeclarative-devel
+BuildRequires:  qt6-base-devel
+BuildRequires:  qt6-declarative-devel
 BuildRequires:  kf6-kcoreaddons-devel
-BuildRequires:  kf6-kconfig-devel
 BuildRequires:  kf6-ki18n-devel
-BuildRequires:  kf6-kpackage-devel
-BuildRequires:  libplasma-devel
-BuildRequires:  kf6-kcmutils-devel
 BuildRequires:  kf6-knotifications-devel
-BuildRequires:  kf6-knotifyconfig-devel
-BuildRequires:  kf6-kglobalaccel-devel
-BuildRequires:  kf6-kguiaddons-devel
-BuildRequires:  kf6-kwidgetsaddons-devel
-BuildRequires:  kf6-kcodecs-devel
-BuildRequires:  kf6-kiconthemes-devel
-BuildRequires:  kf6-kxmlgui-devel
 
 
-# --- Runtime
-Requires:       plasma-workspace >= 6
-
+Requires:       plasma6-workspace
 
 %description
-kfritz A KDE Plasma 6 callmonitor plasmoid for the AVM FRITZ!Box on your desktop.
+KFritz is a KDE Plasma 6 Plasmoid that connects to your AVM FRITZ!Box and
+displays real-time incoming calls. It shows the caller name and number,
+maintains a history of recent calls, and integrates with the KDE
+notification system for alerts.
+
+Source0: _service
 
 %prep
-%autosetup -n kfritz-%{version}
+
+rm -rf ./*
+
+shopt -s nullglob
+picked=""
+for d in %{_sourcedir}/kfritz-* %{_sourcedir}/KFritz-* %{_sourcedir}/kfritz ; do
+  if [ -d "$d" ] && [ -f "$d/CMakeLists.txt" ]; then
+    picked="$d"
+    break
+  fi
+done
+
+if [ -n "$picked" ]; then
+  cp -a "$picked"/. .
+else
+  for f in %{_sourcedir}/* ; do
+    base="$(basename "$f")"
+    case "$base" in
+      *.spec|*.dsc|*.changes|*.obsinfo|_service|service_attic|screenshot|*.patch)
+        continue ;;
+    esac
+    cp -a "$f" .
+  done
+fi
 
 %build
-%cmake -S . \
+%cmake \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DCMAKE_INSTALL_PREFIX=%{_prefix} \
   -DKDE_INSTALL_USE_QT_SYS_PATHS=ON \
   -DKDE_INSTALL_QMLDIR=%{_qt6_qmldir} \
   -DKDE_INSTALL_PLUGINDIR=%{_qt6_plugindir}
 %cmake_build
-
 
 %install
 %cmake_install
@@ -56,12 +75,17 @@ kfritz A KDE Plasma 6 callmonitor plasmoid for the AVM FRITZ!Box on your desktop
 %license LICENSE*
 %doc README*
 %{_datadir}/plasma/plasmoids/de.agundur.kfritz/
-%{_libdir}/qt6/qml/de/agundur/kfritz*/**
+%{_qt6_qmldir}/de/agundur/kfritz/
 %{_datadir}/knotifications6/kfritz.notifyrc
 %{_datadir}/metainfo/de.agundur.kfritz.appdata.xml
 %{_datadir}/locale/*/LC_MESSAGES/plasma_applet_de.agundur.kfritz.mo
 
 %changelog
-* Wed Aug 13 2025 Agundur <info@agundur.de> - 0.1.0
--1
-- beta 1 with translations
+* Wed Jul 08 2026 Alec <info@agundur.de> - 0.1.1
+- First automated OBS release via GitHub Actions obs-submit.yml (was
+  maintained by hand until now — spec had drifted to include unused
+  BuildRequires like libcurl/libssh/libsystemd and was shipping raw
+  plugin/*.cpp,*.h as installed data files)
+- Fixed %files to match the corrected CMake install rules (source files
+  no longer installed anywhere)
+- Pruned BuildRequires to what the plugin actually links against


### PR DESCRIPTION
## Summary
- Stripped `CMakeLists.txt` down to what `kfritzplugin` actually links against (Qt6 Core/Qml/Network/Xml, KF6 I18n/CoreAddons/Notifications). The rest was dead weight copy-pasted from an unrelated KDE Plasma Workspace KCM template (X11/`BUILD_KCM_MOUSE_X11`, Kirigami/KirigamiAddons/QQC2DesktopStyle, KCMUtils/NotifyConfig/GlobalAccel/WidgetsAddons/Codecs/IconThemes/XmlGui, `INSTALL_SDDM_THEME`, `PROJECT_DEP_VERSION`/`ACCOUNTSQT_DEP_VERSION`) — none of it referenced anywhere, verified via grep and confirmed via a real CI build both before and after. Lowered `cmake_minimum_required` 3.31 → 3.16.
- Fixed a real packaging bug: `install(DIRECTORY package/ ...)` was shipping raw `plugin/*.cpp`/`*.h`/`CMakeLists.txt` as installed data files under `/usr/share/plasma/plasmoids/de.agundur.kfritz/plugin/` on every install — confirmed present in the live OBS spec's `%files`. The compiled plugin binary installs correctly and separately via `ecm_add_qml_module`. Verified the fix by extracting a built `.deb` and diffing its contents. This also made a Debian-only `rm -f .../plugin/*.{cpp,h,CMakeLists.txt}` workaround in `debian/rules` obsolete — removed.
- `debian/control` Build-Depends pruned to match (dropped `libplasma-dev`, `libkirigami-dev`, and ~10 other unused `libkf6*-dev` packages).
- `packaging/kfritz.spec` rewritten: matches the pruned dependency set, fixes the same source-shipping bug in `%files`, drops a pile of unexplained `pkgconfig(libcurl)`/`libssh`/`libsystemd`/etc. BuildRequires that had accumulated on the live OBS package (looks like trial-and-error debugging residue).
- New `.github/workflows/obs-submit.yml` (same pattern as KClaude/KPictureFrame/OSBMonitor/EZMonitor): overwrites the OBS-side spec + pins `_service` to the release tag on every `git tag vX.Y.Z`, so the spec drift found on this PR can't silently reaccumulate. Not yet live-tested against the real OBS package (verified structurally against a proven pattern instead) — will run for real on the next actual tag.
- Fixed `.github/workflows/deb.yml`: it only uploaded the `.deb` as a workflow artifact before, never reached a GitHub Release. Added a release job (no `.plasmoid` — kfritz needs a compiled C++ plugin, so a plain `package/` zip wouldn't be GHNS-installable).

## Test plan
- [x] `cmake -B build .` + `cmake --install` locally confirmed config succeeds
- [x] Full `.deb` build verified twice via `workflow_dispatch` on this branch (before and after the Build-Depends/install-rule changes)
- [x] Extracted the built `.deb` and confirmed no `.cpp`/`.h`/`CMakeLists.txt` ship, and the compiled `libkfritzplugin.so` lands in the correct Qt QML plugin path
- [ ] `obs-submit.yml` — first real run happens on the next `git tag vX.Y.Z`

🤖 Generated with [Claude Code](https://claude.com/claude-code)