### PR TITLE
Fix malformed main.xml: unclosed Phonebook group

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -22,4 +22,5 @@
     <entry name="CountryCode" type="Int">
       <default>49</default>
     </entry>
+  </group>
 </kcfg>


### PR DESCRIPTION
## Summary
- `package/contents/config/main.xml`'s `<group name="Phonebook">` was never closed with `</group>` before `</kcfg>` — invalid XML. Found while reviewing this file for the upcoming blocklist-phonebook setting.

## Test plan
- [x] Verified well-formed via `python3 -c "import xml.dom.minidom; xml.dom.minidom.parse(...)"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)