### PR TITLE
Play a sound on incoming call

### DIFF
--- a/package/metadata/notifyrc/kfritz.notifyrc
+++ b/package/metadata/notifyrc/kfritz.notifyrc
@@ -6,4 +6,5 @@ Name=KFritz
 Name=Incoming Call
 Comment=Incoming FritzBox call
 Icon=call-incoming
-Action=Popup
+Sound=phone-incoming-call
+Action=Popup|Sound


### PR DESCRIPTION
## Summary
- Adds `Sound=phone-incoming-call` + `Action=Popup|Sound` to `kfritz.notifyrc`. KFritz already fires a real `KNotification("callReceived")`, so no C++ changes needed — Plasma's notification daemon resolves and plays the sound automatically.
- Uses the standard freedesktop sound theme name (part of the freedesktop.org sound naming spec) instead of bundling a custom audio file — already present in the oxygen/ocean/freedesktop sound themes, same convention `plasma_workspace.notifyrc` itself uses.

Fixes #7

## Test plan
- [x] Verified `.notifyrc` still parses correctly (Python configparser)
- [ ] Live test: trigger an incoming call and confirm the sound plays (needs a real call or manual notification trigger — flagging since this wasn't runtime-verified against a live Plasma session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)