### PR TITLE
Phonebook/blocklist quick-actions on incoming calls

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -16,11 +16,20 @@
     </entry>
   </group>
   <group name="Phonebook">
-    <entry name="SelectedPhonebook" type="Int">
-      <default>0</default>
-    </entry>
     <entry name="CountryCode" type="Int">
       <default>49</default>
+    </entry>
+    <entry name="ContactsPhonebooks" type="StringList">
+      <default></default>
+    </entry>
+    <entry name="ContactsWriteTarget" type="Int">
+      <default>-1</default>
+    </entry>
+    <entry name="BlocklistPhonebooks" type="StringList">
+      <default></default>
+    </entry>
+    <entry name="BlocklistWriteTarget" type="Int">
+      <default>-1</default>
     </entry>
   </group>
 </kcfg>

--- a/package/contents/ui/configPhoneBook.qml
+++ b/package/contents/ui/configPhoneBook.qml
@@ -17,13 +17,18 @@ import org.kde.kquickcontrols 2.0 as KQC
 import org.kde.plasma.plasmoid
 
 KCM.SimpleKCM {
+    id: root
+
     property string cfg_Phonebooks
     property int cfg_Port
     property string cfg_Host
     property string cfg_Login
     property string cfg_Password
     property int cfg_CountryCode: 49
-    property int cfg_SelectedPhonebook: 0
+    property var cfg_ContactsPhonebooks: []
+    property int cfg_ContactsWriteTarget: -1
+    property var cfg_BlocklistPhonebooks: []
+    property int cfg_BlocklistWriteTarget: -1
 
     function updatePhonebooks() {
         phonebookModel.clear();
@@ -36,6 +41,48 @@ KCM.SimpleKCM {
         }
     }
 
+    function nameForId(id) {
+        for (let i = 0; i < phonebookModel.count; ++i) {
+            if (phonebookModel.get(i).id === id)
+                return phonebookModel.get(i).name;
+        }
+        return i18n("Phonebook %1", id);
+    }
+
+    function idsAsInts(stringList) {
+        return stringList.map(s => parseInt(s, 10));
+    }
+
+    function addToContacts(id) {
+        const ids = idsAsInts(cfg_ContactsPhonebooks);
+        if (ids.includes(id))
+            return;
+        cfg_ContactsPhonebooks = cfg_ContactsPhonebooks.concat([String(id)]);
+        if (cfg_ContactsWriteTarget === -1)
+            cfg_ContactsWriteTarget = id;
+    }
+
+    function removeFromContacts(id) {
+        cfg_ContactsPhonebooks = idsAsInts(cfg_ContactsPhonebooks).filter(x => x !== id).map(String);
+        if (cfg_ContactsWriteTarget === id)
+            cfg_ContactsWriteTarget = cfg_ContactsPhonebooks.length > 0 ? parseInt(cfg_ContactsPhonebooks[0], 10) : -1;
+    }
+
+    function addToBlocklist(id) {
+        const ids = idsAsInts(cfg_BlocklistPhonebooks);
+        if (ids.includes(id))
+            return;
+        cfg_BlocklistPhonebooks = cfg_BlocklistPhonebooks.concat([String(id)]);
+        if (cfg_BlocklistWriteTarget === -1)
+            cfg_BlocklistWriteTarget = id;
+    }
+
+    function removeFromBlocklist(id) {
+        cfg_BlocklistPhonebooks = idsAsInts(cfg_BlocklistPhonebooks).filter(x => x !== id).map(String);
+        if (cfg_BlocklistWriteTarget === id)
+            cfg_BlocklistWriteTarget = cfg_BlocklistPhonebooks.length > 0 ? parseInt(cfg_BlocklistPhonebooks[0], 10) : -1;
+    }
+
     Component.onCompleted: updatePhonebooks()
 
     Connections {
@@ -46,67 +93,158 @@ KCM.SimpleKCM {
         target: plugin
     }
 
-    Kirigami.FormLayout {
+    ColumnLayout {
+        anchors.fill: parent
         anchors.margins: Kirigami.Units.largeSpacing
+        spacing: Kirigami.Units.largeSpacing
 
-        QtControls.SpinBox {
-            id: countrySpinBox
+        Kirigami.FormLayout {
+            Layout.fillWidth: true
 
-            value: cfg_CountryCode
-            Kirigami.FormData.label: i18n("Country code: +")
-            from: 1
-            to: 999
-            stepSize: 1
-            textFromValue: function(value) {
-                return value;
+            QtControls.SpinBox {
+                id: countrySpinBox
+
+                value: cfg_CountryCode
+                Kirigami.FormData.label: i18n("Country code: +")
+                from: 1
+                to: 999
+                stepSize: 1
+                textFromValue: function(value) {
+                    return value;
+                }
+                onValueChanged: cfg_CountryCode = textFromValue(value)
             }
-            onValueChanged: cfg_CountryCode = textFromValue(value)
-        }
 
-        Item {
-            Kirigami.FormData.label: "" // leere Spalte 1
-            implicitHeight: Kirigami.Units.largeSpacing
+            QtControls.Button {
+                id: getPhonebooks
+
+                text: i18n("Get Phonebook")
+                onClicked: {
+                    cfg_Phonebooks = plugin.getPhonebookList(cfg_Host, cfg_Port, cfg_Login, cfg_Password).join(", ");
+                }
+            }
+
         }
 
         Kirigami.Separator {
-            // implicitHeight: Kirigami.Units.largeSpacing
-
             Layout.fillWidth: true
-            Layout.alignment: Qt.AlignVCenter
-            Layout.topMargin: Kirigami.Units.largeSpacing
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+
+            Kirigami.Heading {
+                level: 3
+                text: i18n("Add a phonebook")
+                Layout.fillWidth: true
+            }
+
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+
+            QtControls.ComboBox {
+                id: addBox
+
+                Layout.fillWidth: true
+                model: phonebookModel
+                textRole: "name"
+                valueRole: "id"
+            }
+
+            QtControls.Button {
+                text: i18n("Add to Contacts")
+                enabled: addBox.currentIndex >= 0
+                onClicked: addToContacts(phonebookModel.get(addBox.currentIndex).id)
+            }
+
+            QtControls.Button {
+                text: i18n("Add to Blocklist")
+                enabled: addBox.currentIndex >= 0
+                onClicked: addToBlocklist(phonebookModel.get(addBox.currentIndex).id)
+            }
+
+        }
+
+        Kirigami.Heading {
+            level: 3
+            text: i18n("Contacts sources (used for caller ID)")
+        }
+
+        QtControls.Label {
+            visible: cfg_ContactsPhonebooks.length === 0
+            text: i18n("None assigned yet.")
+            opacity: 0.6
+        }
+
+        Repeater {
+            model: idsAsInts(cfg_ContactsPhonebooks)
+
+            delegate: RowLayout {
+                required property int modelData
+
+                Layout.fillWidth: true
+
+                QtControls.RadioButton {
+                    text: nameForId(modelData)
+                    checked: cfg_ContactsWriteTarget === modelData
+                    onClicked: cfg_ContactsWriteTarget = modelData
+                    Layout.fillWidth: true
+                }
+
+                QtControls.ToolTip.visible: hovered
+                QtControls.ToolTip.text: i18n("Write target — new contacts are added here")
+
+                QtControls.ToolButton {
+                    icon.name: "edit-delete"
+                    onClicked: removeFromContacts(modelData)
+                }
+
+            }
+
+        }
+
+        Kirigami.Heading {
+            level: 3
+            text: i18n("Blocklist sources")
+        }
+
+        QtControls.Label {
+            visible: cfg_BlocklistPhonebooks.length === 0
+            text: i18n("None assigned yet.")
+            opacity: 0.6
+        }
+
+        Repeater {
+            model: idsAsInts(cfg_BlocklistPhonebooks)
+
+            delegate: RowLayout {
+                required property int modelData
+
+                Layout.fillWidth: true
+
+                QtControls.RadioButton {
+                    text: nameForId(modelData)
+                    checked: cfg_BlocklistWriteTarget === modelData
+                    onClicked: cfg_BlocklistWriteTarget = modelData
+                    Layout.fillWidth: true
+                }
+
+                QtControls.ToolTip.visible: hovered
+                QtControls.ToolTip.text: i18n("Write target — the \"Add to Blocklist\" button on an incoming call writes here (e.g. keep a WebDAV-synced list read-only by never selecting it here)")
+
+                QtControls.ToolButton {
+                    icon.name: "edit-delete"
+                    onClicked: removeFromBlocklist(modelData)
+                }
+
+            }
+
         }
 
         Item {
-            Kirigami.FormData.label: "" // leere Spalte 1
-            implicitHeight: Kirigami.Units.largeSpacing
-        }
-
-        QtControls.Button {
-            id: getPhonebooks
-
-            text: i18n("Get Phonebook")
-            onClicked: {
-                cfg_Phonebooks = plugin.getPhonebookList(cfg_Host, cfg_Port, cfg_Login, cfg_Password).join(", ");
-            }
-            Layout.topMargin: Kirigami.Units.largeSpacing
-        }
-
-        QtControls.ComboBox {
-            model: phonebookModel
-            textRole: "name"
-            valueRole: "id"
-            Kirigami.FormData.label: i18n("Phonebook:")
-            currentIndex: {
-                for (var i = 0; i < phonebookModel.count; ++i) {
-                    if (phonebookModel.get(i).id === cfg_SelectedPhonebook)
-                        return i;
-
-                }
-                return 0;
-            }
-            onActivated: {
-                cfg_SelectedPhonebook = phonebookModel.get(currentIndex).id;
-            }
+            Layout.fillHeight: true
         }
 
     }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -221,7 +221,7 @@ PlasmoidItem {
 
                     Controls.Button {
                         text: i18n("Add to Contacts")
-                        enabled: Plasmoid.configuration.ContactsWriteTarget !== -1
+                        enabled: Plasmoid.configuration.ContactsWriteTarget !== -1 && newContactName.text.length > 0
                         onClicked: {
                             plugin.addPhonebookEntry(Plasmoid.configuration.ContactsWriteTarget, newContactName.text, plugin.currentCallerNumber, newContactType.typeValues[newContactType.currentIndex]);
                             newContactName.text = "";

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -63,7 +63,8 @@ PlasmoidItem {
     Component.onCompleted: {
         plugin.setHost(Plasmoid.configuration.Host);
         plugin.connectToFritzBox();
-        plugin.loadPhonebook(Plasmoid.configuration.SelectedPhonebook, Plasmoid.configuration.CountryCode);
+        plugin.setContactsPhonebooks(Plasmoid.configuration.ContactsPhonebooks, Plasmoid.configuration.CountryCode);
+        plugin.setBlocklistPhonebooks(Plasmoid.configuration.BlocklistPhonebooks, Plasmoid.configuration.CountryCode);
     }
 
     KFritzCorePlugin {
@@ -108,6 +109,7 @@ PlasmoidItem {
                 required property string name
                 required property string number
                 required property string time
+                required property bool blocked
 
                 // Kein Hintergrund zeichnen:
                 background: null
@@ -126,16 +128,17 @@ PlasmoidItem {
 
                     // optional: Icon
                     Kirigami.Icon {
-                        source: "user"
+                        source: blocked ? "call-stop" : "user"
                         Layout.alignment: Qt.AlignVCenter
                     }
 
                     Text {
-                        text: "<b>" + name + "</b> " + number + " – " + time
+                        text: blocked ? number : "<b>" + name + "</b> " + number + " – " + time
                         textFormat: Text.RichText
                         wrapMode: Text.NoWrap
                         elide: Text.ElideRight
-                        color: Kirigami.Theme.textColor
+                        font.strikeout: blocked
+                        color: blocked ? "red" : Kirigami.Theme.textColor
                         Layout.fillWidth: true
                         Layout.alignment: Qt.AlignVCenter
                     }
@@ -184,6 +187,51 @@ PlasmoidItem {
                     HelpTipButton {
                         helpText: i18n("Dial: #96*5* to enable the CallMonitor on your Fritz!Box")
                         Layout.alignment: Qt.AlignVCenter
+                    }
+
+                }
+
+            }
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                visible: showCallerInfo && plugin.callerUnknown
+
+                Controls.Label {
+                    text: i18n("Unknown number: %1", plugin.currentCallerNumber)
+                }
+
+                RowLayout {
+                    Layout.fillWidth: true
+
+                    Controls.TextField {
+                        id: newContactName
+
+                        placeholderText: i18n("Name")
+                        Layout.fillWidth: true
+                    }
+
+                    Controls.ComboBox {
+                        id: newContactType
+
+                        property var typeValues: ["home", "mobile", "work"]
+
+                        model: [i18n("Private"), i18n("Mobile"), i18n("Business")]
+                    }
+
+                    Controls.Button {
+                        text: i18n("Add to Contacts")
+                        enabled: Plasmoid.configuration.ContactsWriteTarget !== -1
+                        onClicked: {
+                            plugin.addPhonebookEntry(Plasmoid.configuration.ContactsWriteTarget, newContactName.text, plugin.currentCallerNumber, newContactType.typeValues[newContactType.currentIndex]);
+                            newContactName.text = "";
+                        }
+                    }
+
+                    Controls.Button {
+                        text: i18n("Add to Blocklist")
+                        enabled: Plasmoid.configuration.BlocklistWriteTarget !== -1
+                        onClicked: plugin.addPhonebookEntry(Plasmoid.configuration.BlocklistWriteTarget, i18n("Blocked"), plugin.currentCallerNumber, "home")
                     }
 
                 }

--- a/package/plugin/CMakeLists.txt
+++ b/package/plugin/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(kfritzplugin PRIVATE
     FritzCallMonitor.cpp
     FritzDeviceInfoFetcher.cpp
     FritzPhonebookFetcher.cpp
+    FritzSOAP.cpp
     KFritzCorePlugin.cpp
     PhonebookCache.cpp
     RecentCallsModel.cpp

--- a/package/plugin/FritzPhonebookFetcher.cpp
+++ b/package/plugin/FritzPhonebookFetcher.cpp
@@ -1,5 +1,4 @@
 #include "FritzPhonebookFetcher.h"
-#include <QAuthenticator>
 #include <QCoreApplication>
 #include <QDebug>
 #include <QDir>
@@ -22,25 +21,29 @@ FritzPhonebookFetcher::FritzPhonebookFetcher(QObject *parent)
 void FritzPhonebookFetcher::setHost(const QString &host)
 {
     m_host = host;
+    m_soap.setHost(host);
 }
 void FritzPhonebookFetcher::setPort(int port)
 {
     m_port = port;
+    m_soap.setPort(port);
 }
 void FritzPhonebookFetcher::setUsername(const QString &user)
 {
     m_user = user;
+    m_soap.setUsername(user);
 }
 void FritzPhonebookFetcher::setPassword(const QString &pass)
 {
     m_pass = pass;
+    m_soap.setPassword(pass);
 }
 
 QStringList FritzPhonebookFetcher::getPhonebookList()
 {
     const QString body = u"<u:GetPhonebookList xmlns:u=\"urn:dslforum-org:service:X_AVM-DE_OnTel:1\"/>"_s;
 
-    const QString response = sendSoapRequest(u"urn:dslforum-org:service:X_AVM-DE_OnTel:1"_s, u"GetPhonebookList"_s, body, u"/upnp/control/x_contact"_s);
+    const QString response = m_soap.sendRequest(u"urn:dslforum-org:service:X_AVM-DE_OnTel:1"_s, u"GetPhonebookList"_s, body, u"/upnp/control/x_contact"_s);
 
     QStringList phonebooks;
     QXmlStreamReader xml(response);
@@ -121,7 +124,7 @@ QString FritzPhonebookFetcher::getPhonebookUrl(int phonebookId)
                          u"<NewPhonebookID>"_s + QString::number(phonebookId) + u"</NewPhonebookID>"
                          u"</u:GetPhonebook>"_s;
 
-    const QString response = sendSoapRequest(u"urn:dslforum-org:service:X_AVM-DE_OnTel:1"_s, u"GetPhonebook"_s, body, u"/upnp/control/x_contact"_s);
+    const QString response = m_soap.sendRequest(u"urn:dslforum-org:service:X_AVM-DE_OnTel:1"_s, u"GetPhonebook"_s, body, u"/upnp/control/x_contact"_s);
 
     if (response.isEmpty()) {
         qWarning() << "Empty SOAP response for GetPhonebook";
@@ -143,52 +146,28 @@ QString FritzPhonebookFetcher::getPhonebookUrl(int phonebookId)
     return {};
 }
 
-QString FritzPhonebookFetcher::sendSoapRequest(const QString &service, const QString &action, const QString &body, const QString &controlUrl)
+bool FritzPhonebookFetcher::addPhonebookEntry(int phonebookId, const QString &name, const QString &number, const QString &type)
 {
-    const QUrl url = QUrl(u"http://"_s + m_host + u":"_s + QString::number(m_port) + controlUrl);
+    // Official contact schema, TR-064 Support – X_AVM-DE_OnTel, chapter 5.1
+    // "Phonebook Content". No <uniqueid> tag => always adds a new entry
+    // (SetPhonebookEntry with an empty NewPhonebookEntryID does the same).
+    const QString entryData = u"<contact><category>0</category><person><realName>"_s + name.toHtmlEscaped() + u"</realName></person><telephony><services/><number type=\""_s
+        + type.toHtmlEscaped() + u"\" prio=\"0\">"_s + number.toHtmlEscaped() + u"</number></telephony></contact>"_s;
 
-    QNetworkRequest request(url);
+    const QString body = u"<u:SetPhonebookEntry xmlns:u=\"urn:dslforum-org:service:X_AVM-DE_OnTel:1\">"
+                         u"<NewPhonebookID>"_s
+        + QString::number(phonebookId)
+        + u"</NewPhonebookID>"
+          u"<NewPhonebookEntryID></NewPhonebookEntryID>"
+          u"<NewPhonebookEntryData>"_s
+        + entryData.toHtmlEscaped() + u"</NewPhonebookEntryData></u:SetPhonebookEntry>"_s;
 
-    // 🔐 Authorization
-    QString credentials = m_user + u":"_s + m_pass;
-    QByteArray auth = "Basic " + credentials.toUtf8().toBase64();
+    const QString response = m_soap.sendRequest(u"urn:dslforum-org:service:X_AVM-DE_OnTel:1"_s, u"SetPhonebookEntry"_s, body, u"/upnp/control/x_contact"_s);
 
-    request.setRawHeader("Authorization", auth);
-
-    // 📄 Content & SOAP
-    request.setHeader(QNetworkRequest::ContentTypeHeader, QStringLiteral("text/xml; charset=\"utf-8\""));
-
-    request.setRawHeader("SOAPACTION", "\"" + service.toUtf8() + "#" + action.toUtf8() + "\"");
-
-    const QString envelope =
-        uR"(<?xml version="1.0" encoding="utf-8"?>
-<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"
-            s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
-  <s:Body>)"_s
-        + body + u"</s:Body></s:Envelope>"_s;
-
-    QNetworkAccessManager nam;
-
-    // 🔐 Optional: Auth-Fallback über QAuthenticator (nur wenn RawHeader nicht greift)
-    QObject::connect(&nam, &QNetworkAccessManager::authenticationRequired, [this](QNetworkReply * /*reply*/, QAuthenticator *authenticator) {
-        qDebug() << "authenticationRequired() triggered!";
-        authenticator->setUser(m_user);
-        authenticator->setPassword(m_pass);
-    });
-
-    QNetworkReply *reply = nam.post(request, envelope.toUtf8());
-
-    QEventLoop loop;
-    QObject::connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
-    loop.exec();
-
-    QString result;
-    if (reply->error() != QNetworkReply::NoError) {
-        qWarning() << "SOAP request failed:" << reply->errorString();
-    } else {
-        result = QString::fromUtf8(reply->readAll());
+    if (response.contains(u"<errorCode>"_s)) {
+        qWarning() << "SetPhonebookEntry failed:" << response;
+        return false;
     }
 
-    reply->deleteLater();
-    return result;
+    return true;
 }

--- a/package/plugin/FritzPhonebookFetcher.h
+++ b/package/plugin/FritzPhonebookFetcher.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "FritzSOAP.h"
 #include <QObject>
 #include <QQmlEngine>
 #include <QStringList>
@@ -25,6 +26,11 @@ public:
 
     QStringList getPhonebookList();
 
+    // Adds a new entry to phonebook `phonebookId` (SetPhonebookEntry, official
+    // AVM contact XML schema — see TR-064 Support X_AVM-DE_OnTel, chapter 5.1).
+    // Returns true if the SOAP call didn't report an error.
+    bool addPhonebookEntry(int phonebookId, const QString &name, const QString &number, const QString &type = QStringLiteral("home"));
+
 Q_SIGNALS:
     void phonebookDownloaded(int id, const QString &path);
 
@@ -34,6 +40,5 @@ private:
 
     QString m_host, m_user, m_pass;
     int m_port = 49000;
-
-    QString sendSoapRequest(const QString &service, const QString &action, const QString &body, const QString &controlUrl);
+    FritzSOAP m_soap;
 };

--- a/package/plugin/FritzSOAP.cpp
+++ b/package/plugin/FritzSOAP.cpp
@@ -1,0 +1,81 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Agundur <info@agundur.de>
+ *
+ * SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only OR LicenseRef-KDE-Accepted-GPL
+ */
+
+#include "FritzSOAP.h"
+
+#include <QAuthenticator>
+#include <QDebug>
+#include <QEventLoop>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QUrl>
+
+using namespace Qt::StringLiterals;
+
+void FritzSOAP::setHost(const QString &host)
+{
+    m_host = host;
+}
+
+void FritzSOAP::setPort(int port)
+{
+    m_port = port;
+}
+
+void FritzSOAP::setUsername(const QString &user)
+{
+    m_user = user;
+}
+
+void FritzSOAP::setPassword(const QString &pass)
+{
+    m_pass = pass;
+}
+
+QString FritzSOAP::sendRequest(const QString &service, const QString &action, const QString &body, const QString &controlUrl) const
+{
+    const QUrl url = QUrl(u"http://"_s + m_host + u":"_s + QString::number(m_port) + controlUrl);
+
+    QNetworkRequest request(url);
+
+    QString credentials = m_user + u":"_s + m_pass;
+    QByteArray auth = "Basic " + credentials.toUtf8().toBase64();
+    request.setRawHeader("Authorization", auth);
+
+    request.setHeader(QNetworkRequest::ContentTypeHeader, QStringLiteral("text/xml; charset=\"utf-8\""));
+    request.setRawHeader("SOAPACTION", "\"" + service.toUtf8() + "#" + action.toUtf8() + "\"");
+
+    const QString envelope =
+        uR"(<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"
+            s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+  <s:Body>)"_s
+        + body + u"</s:Body></s:Envelope>"_s;
+
+    QNetworkAccessManager nam;
+
+    QObject::connect(&nam, &QNetworkAccessManager::authenticationRequired, [this](QNetworkReply * /*reply*/, QAuthenticator *authenticator) {
+        authenticator->setUser(m_user);
+        authenticator->setPassword(m_pass);
+    });
+
+    QNetworkReply *reply = nam.post(request, envelope.toUtf8());
+
+    QEventLoop loop;
+    QObject::connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
+    loop.exec();
+
+    QString result;
+    if (reply->error() != QNetworkReply::NoError) {
+        qWarning() << "SOAP request failed:" << action << reply->errorString();
+    } else {
+        result = QString::fromUtf8(reply->readAll());
+    }
+
+    reply->deleteLater();
+    return result;
+}

--- a/package/plugin/FritzSOAP.h
+++ b/package/plugin/FritzSOAP.h
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Agundur <info@agundur.de>
+ *
+ * SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only OR LicenseRef-KDE-Accepted-GPL
+ */
+
+#pragma once
+
+#include <QString>
+
+// TR-064 SOAP transport shared by everything that talks to the FritzBox
+// (phonebook read/write, call barring, ...). Extracted out of
+// FritzPhonebookFetcher, which used to be the only caller.
+class FritzSOAP
+{
+public:
+    void setHost(const QString &host);
+    void setPort(int port);
+    void setUsername(const QString &user);
+    void setPassword(const QString &pass);
+
+    QString sendRequest(const QString &service, const QString &action, const QString &body, const QString &controlUrl) const;
+
+private:
+    QString m_host, m_user, m_pass;
+    int m_port = 49000;
+};

--- a/package/plugin/KFritzCorePlugin.cpp
+++ b/package/plugin/KFritzCorePlugin.cpp
@@ -168,6 +168,21 @@ QString KFritzCorePlugin::callerInfo() const
     return m_callerInfo;
 }
 
+QString KFritzCorePlugin::currentCallerNumber() const
+{
+    return m_currentCallerNumber;
+}
+
+bool KFritzCorePlugin::callerBlocked() const
+{
+    return m_callerBlocked;
+}
+
+bool KFritzCorePlugin::callerUnknown() const
+{
+    return m_callerUnknown;
+}
+
 void KFritzCorePlugin::loadPhonebook(int phonebookId, int countryCode)
 {
     QString baseDir = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + u"/phonebooks"_s;
@@ -175,13 +190,44 @@ void KFritzCorePlugin::loadPhonebook(int phonebookId, int countryCode)
 
     qDebug() << "Lade Telefonbuch:" << path;
     QString countryPrefix = u"+" + QString::number(countryCode);
-    m_lookup.loadFromFile(path, countryPrefix);
+    m_lookups[phonebookId].loadFromFile(path, countryPrefix);
+}
+
+void KFritzCorePlugin::setContactsPhonebooks(const QVariantList &ids, int countryCode)
+{
+    m_contactsIds.clear();
+    for (const QVariant &v : ids) {
+        int id = v.toInt();
+        m_contactsIds << id;
+        loadPhonebook(id, countryCode);
+    }
+}
+
+void KFritzCorePlugin::setBlocklistPhonebooks(const QVariantList &ids, int countryCode)
+{
+    m_blocklistIds.clear();
+    for (const QVariant &v : ids) {
+        int id = v.toInt();
+        m_blocklistIds << id;
+        loadPhonebook(id, countryCode);
+    }
+}
+
+bool KFritzCorePlugin::addPhonebookEntry(int phonebookId, const QString &name, const QString &number, const QString &type)
+{
+    return m_fetcher.addPhonebookEntry(phonebookId, name, number, type);
 }
 
 QString KFritzCorePlugin::resolveName(const QString &number) const
 {
-    return m_lookup.resolveName(number);
+    for (int id : m_contactsIds) {
+        const QString name = m_lookups.value(id).resolveName(number);
+        if (!name.isEmpty())
+            return name;
+    }
+    return {};
 }
+
 /************************* Call history *******************************/
 
 QStringList KFritzCorePlugin::recentCalls() const
@@ -191,8 +237,42 @@ QStringList KFritzCorePlugin::recentCalls() const
 
 void KFritzCorePlugin::handleIncomingCall(const QString &number)
 {
-    QString name = m_lookup.resolveName(number);
+    bool blocked = false;
+    for (int id : m_blocklistIds) {
+        if (!m_lookups.value(id).resolveName(number).isEmpty()) {
+            blocked = true;
+            break;
+        }
+    }
+
+    QString name;
+    if (!blocked) {
+        name = resolveName(number);
+    }
+    bool unknown = !blocked && name.isEmpty();
+
     QString timestamp = QDateTime::currentDateTime().toString(u"hh:mm:ss"_s);
+
+    m_currentCallerNumber = number;
+    m_callerBlocked = blocked;
+    m_callerUnknown = unknown;
+    m_callerInfo = !name.isEmpty() ? name + u" (" + number + u")" : number;
+    Q_EMIT callerInfoChanged();
+
+    QString entry = timestamp + u" - "_s + (!name.isEmpty() ? name + u" (" + number + u")" : number);
+    m_recentCalls.prepend(entry);
+
+    if (m_recentCallsModel)
+        m_recentCallsModel->addCall(name, number, timestamp, blocked);
+
+    Q_EMIT recentCallsChanged();
+
+    // Blocked calls are meant to not interrupt -- no system notification at
+    // all, they only show up (styled) in the call list above.
+    if (blocked) {
+        qDebug() << "Blocked call from" << number;
+        return;
+    }
 
     QString message = name.isEmpty() ? i18n("Incoming call from %1", number) : i18n("Incoming call from %1 (%2)", name, number);
 
@@ -200,24 +280,10 @@ void KFritzCorePlugin::handleIncomingCall(const QString &number)
     notification->setComponentName(QStringLiteral("kfritz"));
     notification->setTitle(i18n("FritzBox Call"));
     notification->setText(message);
-    notification->setIconName(QStringLiteral("call-incoming")); // z. B. phone-incoming-symbolic
+    notification->setIconName(QStringLiteral("call-incoming"));
     notification->sendEvent();
 
-    QString entry = timestamp + u" – "_s + (!name.isEmpty() ? name + u" (" + number + u")" : number);
-
-    m_callerInfo = !name.isEmpty() ? name + u" (" + number + u")" : number;
-    Q_EMIT callerInfoChanged();
-
-    m_recentCalls.prepend(entry);
-
-    if (m_recentCallsModel)
-        m_recentCallsModel->addCall(name, number, timestamp);
-
-    // if (m_recentCalls.size() > 20) // nur letzte 20 anzeigen
-    //     m_recentCalls.removeLast();
-    qDebug() << "📞 :" << number << "→ recentCalls:" << m_recentCalls;
-
-    Q_EMIT recentCallsChanged();
+    qDebug() << "Incoming call:" << number << "-> recentCalls:" << m_recentCalls;
 }
 
 QAbstractListModel *KFritzCorePlugin::recentCallsModel() const

--- a/package/plugin/KFritzCorePlugin.h
+++ b/package/plugin/KFritzCorePlugin.h
@@ -11,6 +11,7 @@
 #include "FritzPhonebookFetcher.h"
 #include "PhonebookCache.h"
 #include "RecentCallsModel.h"
+#include <QHash>
 #include <QObject>
 #include <QQmlEngine>
 #include <QStringList>
@@ -23,6 +24,9 @@ class KFritzCorePlugin : public QObject
     Q_PROPERTY(bool callMonitorConnected READ callMonitorConnected NOTIFY callMonitorConnectedChanged)
     Q_PROPERTY(QString currentCaller READ currentCaller NOTIFY currentCallerChanged)
     Q_PROPERTY(QString callerInfo READ callerInfo NOTIFY callerInfoChanged)
+    Q_PROPERTY(QString currentCallerNumber READ currentCallerNumber NOTIFY callerInfoChanged)
+    Q_PROPERTY(bool callerBlocked READ callerBlocked NOTIFY callerInfoChanged)
+    Q_PROPERTY(bool callerUnknown READ callerUnknown NOTIFY callerInfoChanged)
     Q_PROPERTY(QStringList recentCalls READ recentCalls NOTIFY recentCallsChanged)
     Q_PROPERTY(QAbstractListModel *recentCallsModel READ recentCallsModel NOTIFY recentCallsChanged)
 
@@ -35,6 +39,9 @@ public:
     QString currentCaller() const;
     QStringList recentCalls() const;
     QString callerInfo() const;
+    QString currentCallerNumber() const;
+    bool callerBlocked() const;
+    bool callerUnknown() const;
     QAbstractListModel *recentCallsModel() const;
 
     Q_INVOKABLE QVariantList getPhonebookList(const QString &host, int port, const QString &user, const QString &password);
@@ -42,6 +49,16 @@ public:
     Q_INVOKABLE void connectToFritzBox();
     Q_INVOKABLE void setHost(const QString &host);
     Q_INVOKABLE QString resolveName(const QString &number) const;
+
+    // ids assigned to each role (Settings), used to check an incoming number
+    // against every phonebook in that role, not just one.
+    Q_INVOKABLE void setContactsPhonebooks(const QVariantList &ids, int countryCode);
+    Q_INVOKABLE void setBlocklistPhonebooks(const QVariantList &ids, int countryCode);
+
+    // Adds `number` to phonebook `phonebookId` — the caller (QML) decides
+    // which id that is (ContactsWriteTarget/BlocklistWriteTarget), so this
+    // stays a thin, stateless wrapper.
+    Q_INVOKABLE bool addPhonebookEntry(int phonebookId, const QString &name, const QString &number, const QString &type);
 
 public Q_SLOTS:
     void loadPhonebook(int phonebookId, int countryCode);
@@ -59,7 +76,12 @@ private:
     FritzCallMonitor *m_callMonitor = nullptr;
     QString m_host;
     QString m_callerInfo;
-    PhonebookLookup m_lookup;
+    QString m_currentCallerNumber;
+    bool m_callerBlocked = false;
+    bool m_callerUnknown = false;
+    QHash<int, PhonebookLookup> m_lookups;
+    QList<int> m_contactsIds;
+    QList<int> m_blocklistIds;
     QStringList m_recentCalls;
     RecentCallsModel *m_recentCallsModel = nullptr;
 

--- a/package/plugin/RecentCallsModel.cpp
+++ b/package/plugin/RecentCallsModel.cpp
@@ -25,6 +25,8 @@ QVariant RecentCallsModel::data(const QModelIndex &index, int role) const
         return call.number;
     case TimeRole:
         return call.time;
+    case BlockedRole:
+        return call.blocked;
     default:
         return {};
     }
@@ -32,14 +34,14 @@ QVariant RecentCallsModel::data(const QModelIndex &index, int role) const
 
 QHash<int, QByteArray> RecentCallsModel::roleNames() const
 {
-    return {{NameRole, "name"}, {NumberRole, "number"}, {TimeRole, "time"}};
+    return {{NameRole, "name"}, {NumberRole, "number"}, {TimeRole, "time"}, {BlockedRole, "blocked"}};
 }
 
-void RecentCallsModel::addCall(const QString &name, const QString &number, const QString &time)
+void RecentCallsModel::addCall(const QString &name, const QString &number, const QString &time, bool blocked)
 {
-    qDebug() << "📞 RecentCallsModel::addCall:" << name << number << time;
+    qDebug() << "RecentCallsModel::addCall:" << name << number << time << "blocked:" << blocked;
     beginInsertRows(QModelIndex(), 0, 0);
-    m_calls.prepend({name, number, time});
+    m_calls.prepend({name, number, time, blocked});
     if (m_calls.size() > 20) // optional: max. 20 Anrufe speichern
         m_calls.removeLast();
     endInsertRows();

--- a/package/plugin/RecentCallsModel.h
+++ b/package/plugin/RecentCallsModel.h
@@ -21,7 +21,8 @@ public:
     enum Roles {
         NameRole = Qt::UserRole + 1,
         NumberRole,
-        TimeRole
+        TimeRole,
+        BlockedRole
     };
 
     explicit RecentCallsModel(QObject *parent = nullptr);
@@ -30,13 +31,14 @@ public:
     QVariant data(const QModelIndex &index, int role) const override;
     QHash<int, QByteArray> roleNames() const override;
 
-    void addCall(const QString &name, const QString &number, const QString &time);
+    void addCall(const QString &name, const QString &number, const QString &time, bool blocked = false);
 
 private:
     struct CallEntry {
         QString name;
         QString number;
         QString time;
+        bool blocked = false;
     };
 
     QVector<CallEntry> m_calls;


### PR DESCRIPTION
## Summary
- Extracted `FritzSOAP` out of `FritzPhonebookFetcher` (shared TR-064 transport, now also used by the new write action).
- `FritzPhonebookFetcher::addPhonebookEntry()` — writes a contact via `SetPhonebookEntry`, using the official AVM contact XML schema (verified against the current TR-064 Support – X_AVM-DE_OnTel spec PDF, not a forum mockup).
- `KFritzCorePlugin` now tracks phonebooks per **role** instead of a single `SelectedPhonebook`: `ContactsPhonebooks` (caller-ID lookup) and `BlocklistPhonebooks` (checked first on every incoming call).
  - Match in a blocklist-role phonebook → system notification fully suppressed (no popup, no sound), number shown red/struck-through in the call list.
  - No match anywhere → notifies as before, plus inline "Add to Contacts" (name + type) / "Add to Blocklist" actions for that call.
- Each role can have multiple **read** sources but only one designated **write target** (RadioButton per assigned phonebook in `configPhoneBook.qml`) — so a WebDAV-synced blocklist can stay read-only while a hand-maintained one takes new entries, without overwriting on next sync.
- Considered AVM's dedicated `CallBarring` service instead of a designated blocklist phonebook — ruled out, it's capped at 32 entries (Telefonie > Rufbehandlung > Rufsperren), unsuitable for an internet-sourced spam list. Also checked whether "which phonebook is a call-barring source" is readable via TR-064 (would have let KFritz mirror the box's own config) — it isn't exposed by any documented action.

## Test plan
- [x] Full `.deb` build succeeded via `workflow_dispatch` (real C++ compile, not just qmllint)
- [x] Extracted the built `.deb`: compiled plugin, `kfritz.notifyrc`, and `main.xml` all present and correct
- [ ] Live test against a real FRITZ!Box (SOAP write correctness for `SetPhonebookEntry`, actual call-blocking behavior) — not verified against real hardware yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)