### PR TITLE
Show missed calls from while the widget wasn't running

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -31,5 +31,8 @@
     <entry name="BlocklistWriteTarget" type="Int">
       <default>-1</default>
     </entry>
+    <entry name="LastSeenCallId" type="Int">
+      <default>0</default>
+    </entry>
   </group>
 </kcfg>

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -60,11 +60,16 @@ PlasmoidItem {
     Layout.fillHeight: true
     width: 400
     height: 300
+    function checkMissedCalls() {
+        Plasmoid.configuration.LastSeenCallId = plugin.checkMissedCalls(Plasmoid.configuration.LastSeenCallId);
+    }
+
     Component.onCompleted: {
         plugin.setHost(Plasmoid.configuration.Host);
         plugin.connectToFritzBox();
         plugin.setContactsPhonebooks(Plasmoid.configuration.ContactsPhonebooks, Plasmoid.configuration.CountryCode);
         plugin.setBlocklistPhonebooks(Plasmoid.configuration.BlocklistPhonebooks, Plasmoid.configuration.CountryCode);
+        checkMissedCalls();
     }
 
     KFritzCorePlugin {
@@ -182,6 +187,17 @@ PlasmoidItem {
 
                     Item {
                         Layout.fillWidth: true
+                    }
+
+                    Controls.ToolButton {
+                        icon.name: "view-refresh"
+                        text: i18n("Check for missed calls")
+                        display: Controls.ToolButton.IconOnly
+                        Layout.alignment: Qt.AlignVCenter
+                        onClicked: checkMissedCalls()
+
+                        Controls.ToolTip.visible: hovered
+                        Controls.ToolTip.text: text
                     }
 
                     HelpTipButton {

--- a/package/plugin/FritzPhonebookFetcher.cpp
+++ b/package/plugin/FritzPhonebookFetcher.cpp
@@ -171,3 +171,81 @@ bool FritzPhonebookFetcher::addPhonebookEntry(int phonebookId, const QString &na
 
     return true;
 }
+
+QList<FritzCallListEntry> FritzPhonebookFetcher::getCallList(int sinceId)
+{
+    QList<FritzCallListEntry> result;
+
+    const QString body = u"<u:GetCallList xmlns:u=\"urn:dslforum-org:service:X_AVM-DE_OnTel:1\"/>"_s;
+    const QString response = m_soap.sendRequest(u"urn:dslforum-org:service:X_AVM-DE_OnTel:1"_s, u"GetCallList"_s, body, u"/upnp/control/x_contact"_s);
+
+    QString url;
+    QXmlStreamReader urlXml(response);
+    while (!urlXml.atEnd()) {
+        urlXml.readNext();
+        if (urlXml.isStartElement() && urlXml.name() == u"NewCallListURL"_s) {
+            url = urlXml.readElementText().trimmed();
+        }
+    }
+
+    if (url.isEmpty()) {
+        qWarning() << "Empty SOAP response for GetCallList (feature disabled on the box?)";
+        return result;
+    }
+
+    if (sinceId > 0) {
+        url += (url.contains(u'?') ? u"&id="_s : u"?id="_s) + QString::number(sinceId);
+    }
+
+    QNetworkAccessManager nam;
+    QNetworkRequest request{QUrl(url)};
+    QNetworkReply *reply = nam.get(request);
+
+    QEventLoop loop;
+    QObject::connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
+    loop.exec();
+
+    if (reply->error() != QNetworkReply::NoError) {
+        qWarning() << "GetCallList download failed:" << reply->errorString();
+        reply->deleteLater();
+        return result;
+    }
+
+    const QByteArray data = reply->readAll();
+    reply->deleteLater();
+
+    // Official schema, TR-064 Support - X_AVM-DE_OnTel, chapter 5.2 "Call
+    // List Content": <root><Call><Id/><Type/><CallerNumber/><Name/><Date/>...
+    QXmlStreamReader callXml(data);
+    FritzCallListEntry current;
+    bool inCall = false;
+    while (!callXml.atEnd()) {
+        callXml.readNext();
+        if (callXml.isStartElement()) {
+            const QStringView tag = callXml.name();
+            if (tag == u"Call"_s) {
+                inCall = true;
+                current = FritzCallListEntry{};
+            } else if (inCall && tag == u"Id"_s) {
+                current.id = callXml.readElementText().toInt();
+            } else if (inCall && tag == u"Type"_s) {
+                current.type = callXml.readElementText().toInt();
+            } else if (inCall && tag == u"CallerNumber"_s) {
+                current.number = callXml.readElementText();
+            } else if (inCall && tag == u"Name"_s) {
+                current.name = callXml.readElementText();
+            } else if (inCall && tag == u"Date"_s) {
+                current.date = callXml.readElementText();
+            }
+        } else if (callXml.isEndElement() && callXml.name() == u"Call"_s) {
+            inCall = false;
+            result << current;
+        }
+    }
+
+    if (callXml.hasError()) {
+        qWarning() << "Call list XML parse error:" << callXml.errorString();
+    }
+
+    return result;
+}

--- a/package/plugin/FritzPhonebookFetcher.h
+++ b/package/plugin/FritzPhonebookFetcher.h
@@ -11,6 +11,17 @@
 #include <QQmlEngine>
 #include <QStringList>
 
+// One entry from the FritzBox's own call list (GetCallList). Type follows
+// the official AVM enum: 1 incoming, 2 missed, 3 outgoing, 9 active
+// incoming, 10 rejected incoming, 11 active outgoing.
+struct FritzCallListEntry {
+    int id = 0;
+    int type = 0;
+    QString number;
+    QString name;
+    QString date;
+};
+
 class FritzPhonebookFetcher : public QObject
 {
     Q_OBJECT
@@ -30,6 +41,11 @@ public:
     // AVM contact XML schema — see TR-064 Support X_AVM-DE_OnTel, chapter 5.1).
     // Returns true if the SOAP call didn't report an error.
     bool addPhonebookEntry(int phonebookId, const QString &name, const QString &number, const QString &type = QStringLiteral("home"));
+
+    // Fetches the box's own call list (GetCallList). If sinceId > 0, only
+    // calls with a higher unique id are returned (AVM's own "id" URL param —
+    // no local dedup bookkeeping needed).
+    QList<FritzCallListEntry> getCallList(int sinceId = 0);
 
 Q_SIGNALS:
     void phonebookDownloaded(int id, const QString &path);

--- a/package/plugin/KFritzCorePlugin.cpp
+++ b/package/plugin/KFritzCorePlugin.cpp
@@ -235,15 +235,47 @@ QStringList KFritzCorePlugin::recentCalls() const
     return m_recentCalls;
 }
 
-void KFritzCorePlugin::handleIncomingCall(const QString &number)
+bool KFritzCorePlugin::isBlocked(const QString &number) const
 {
-    bool blocked = false;
     for (int id : m_blocklistIds) {
-        if (!m_lookups.value(id).resolveName(number).isEmpty()) {
-            blocked = true;
-            break;
+        if (!m_lookups.value(id).resolveName(number).isEmpty())
+            return true;
+    }
+    return false;
+}
+
+int KFritzCorePlugin::checkMissedCalls(int lastSeenId)
+{
+    const auto entries = m_fetcher.getCallList(lastSeenId);
+
+    int maxId = lastSeenId;
+    bool changed = false;
+
+    for (const FritzCallListEntry &entry : entries) {
+        if (entry.id > maxId)
+            maxId = entry.id;
+
+        if (entry.type != 2) // only "missed"
+            continue;
+
+        const bool blocked = isBlocked(entry.number);
+        const QString name = blocked ? QString{} : (entry.name.isEmpty() ? resolveName(entry.number) : entry.name);
+
+        if (m_recentCallsModel) {
+            m_recentCallsModel->addCall(name, entry.number, entry.date, blocked);
+            changed = true;
         }
     }
+
+    if (changed)
+        Q_EMIT recentCallsChanged();
+
+    return maxId;
+}
+
+void KFritzCorePlugin::handleIncomingCall(const QString &number)
+{
+    bool blocked = isBlocked(number);
 
     QString name;
     if (!blocked) {

--- a/package/plugin/KFritzCorePlugin.h
+++ b/package/plugin/KFritzCorePlugin.h
@@ -60,6 +60,13 @@ public:
     // stays a thin, stateless wrapper.
     Q_INVOKABLE bool addPhonebookEntry(int phonebookId, const QString &name, const QString &number, const QString &type);
 
+    // Fetches missed calls (Type 2) from the box's own call list since
+    // `lastSeenId` (0 = everything the box still has), adds them to
+    // recentCallsModel same as a live call would, and returns the new
+    // highest id seen so QML can persist it (Plasmoid.configuration.
+    // LastSeenCallId) for the next incremental fetch.
+    Q_INVOKABLE int checkMissedCalls(int lastSeenId);
+
 public Q_SLOTS:
     void loadPhonebook(int phonebookId, int countryCode);
     void handleIncomingCall(const QString &number);
@@ -72,6 +79,8 @@ Q_SIGNALS:
     void recentCallsChanged();
 
 private:
+    bool isBlocked(const QString &number) const;
+
     FritzPhonebookFetcher m_fetcher;
     FritzCallMonitor *m_callMonitor = nullptr;
     QString m_host;


### PR DESCRIPTION
## Summary
- `FritzPhonebookFetcher::getCallList()` fetches the FritzBox's own call list (`GetCallList`, `X_AVM-DE_OnTel`) — schema verified against the official TR-064 Support PDF, chapter 5.2.
- Uses AVM's own `id` URL parameter ("calls since this unique id") for incremental fetching — no local dedup bookkeeping, just persist the highest id seen as `Plasmoid.configuration.LastSeenCallId`.
- `KFritzCorePlugin::checkMissedCalls()` filters to Type 2 ("missed"), feeds them into the same `recentCallsModel` a live call uses, and runs the same blocklist check as live calls (extracted the duplicated logic into `isBlocked()`) — a missed call from a blocked number still shows red/struck-through instead of a resolved name.
- Runs once on startup (catches up on anything since the widget last ran) plus a manual refresh button in the header.

## Test plan
- [x] Full `.deb` build succeeded via `workflow_dispatch`, no compile errors
- [ ] Live test against a real FRITZ!Box (actual `GetCallList` response parsing, incremental `id` fetching) — not verified against real hardware yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)